### PR TITLE
Fixes for code scanning alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,6 +79,9 @@ jobs:
           paths:
             - .github/workflows
             - proxy
+          paths-ignore:
+            - proxy/crow_all.h
+            
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/proxy_ci.yml
+++ b/.github/workflows/proxy_ci.yml
@@ -1,5 +1,8 @@
 name: Proxy CI
 
+permissions:
+  contents: read
+
 on: [push, pull_request, workflow_dispatch]
 
 jobs:

--- a/socket/arch/LinuxX64/kprobe.c
+++ b/socket/arch/LinuxX64/kprobe.c
@@ -13,17 +13,17 @@ static bool regs_valid = false;
 
 static int handler_pre(struct kprobe *p, struct pt_regs *regs)
 {
-    /* Only capture register state on the primary CPU (CPU 0) to avoid 
+    /* Only capture register state on the primary CPU (CPU 0) to avoid
      * multiple cores overwriting the same data structure */
     if (smp_processor_id() != 0)
         return 0;
-        
+
     /* Capture the real register state */
     mutex_lock(&regs_mutex);
     captured_regs = *regs;
     regs_valid = true;
     mutex_unlock(&regs_mutex);
-    
+
     return 0;
 }
 
@@ -32,10 +32,10 @@ static ssize_t proc_read(struct file *file, char __user *buffer, size_t count, l
 {
     int len;
     char output[512];
-    
+
     if (*pos > 0)
         return 0;
-    
+
     mutex_lock(&regs_mutex);
     if (!regs_valid) {
         len = snprintf(output, sizeof(output), "No register data captured yet\n");
@@ -43,7 +43,7 @@ static ssize_t proc_read(struct file *file, char __user *buffer, size_t count, l
         len = snprintf(output, sizeof(output),
             "RIP=0x%lx RSP=0x%lx RBP=0x%lx RAX=0x%lx RBX=0x%lx RCX=0x%lx RDX=0x%lx "
             "RSI=0x%lx RDI=0x%lx R8=0x%lx R9=0x%lx R10=0x%lx R11=0x%lx R12=0x%lx "
-            "R13=0x%lx R14=0x%lx R15=0x%lx EFLAGS=0x%lx CS=0x%lx SS=0x%x ORIG_RAX=0x%lx\n",
+            "R13=0x%lx R14=0x%lx R15=0x%lx EFLAGS=0x%lx CS=0x%x SS=0x%x ORIG_RAX=0x%lx\n",
             captured_regs.ip, captured_regs.sp, captured_regs.bp, captured_regs.ax,
             captured_regs.bx, captured_regs.cx, captured_regs.dx, captured_regs.si,
             captured_regs.di, captured_regs.r8, captured_regs.r9, captured_regs.r10,
@@ -52,13 +52,13 @@ static ssize_t proc_read(struct file *file, char __user *buffer, size_t count, l
             captured_regs.orig_ax);
     }
     mutex_unlock(&regs_mutex);
-    
+
     if (count < len)
         return -EINVAL;
-    
+
     if (copy_to_user(buffer, output, len))
         return -EFAULT;
-    
+
     *pos = len;
     return len;
 }
@@ -75,14 +75,14 @@ static struct kprobe kp = {
 static int __init my_kprobe_init(void)
 {
     int ret;
-    
+
     /* Create procfs entry */
     proc_entry = proc_create("panel_regs", 0444, NULL, &proc_fops);
     if (!proc_entry) {
         printk(KERN_ERR "Failed to create /proc/panel_regs\n");
         return -ENOMEM;
     }
-    
+
     /* Register kprobe */
     ret = register_kprobe(&kp);
     if (ret < 0) {
@@ -90,7 +90,7 @@ static int __init my_kprobe_init(void)
         proc_remove(proc_entry);
         return ret;
     }
-    
+
     printk(KERN_INFO "Panel kprobe registered for %s, data available at /proc/panel_regs\n", kp.symbol_name);
     return 0;
 }

--- a/socket/arch/LinuxX64/kprobe.c
+++ b/socket/arch/LinuxX64/kprobe.c
@@ -43,7 +43,7 @@ static ssize_t proc_read(struct file *file, char __user *buffer, size_t count, l
         len = snprintf(output, sizeof(output),
             "RIP=0x%lx RSP=0x%lx RBP=0x%lx RAX=0x%lx RBX=0x%lx RCX=0x%lx RDX=0x%lx "
             "RSI=0x%lx RDI=0x%lx R8=0x%lx R9=0x%lx R10=0x%lx R11=0x%lx R12=0x%lx "
-            "R13=0x%lx R14=0x%lx R15=0x%lx EFLAGS=0x%lx CS=0x%lx SS=0x%lx ORIG_RAX=0x%lx\n",
+            "R13=0x%lx R14=0x%lx R15=0x%lx EFLAGS=0x%lx CS=0x%lx SS=0x%x ORIG_RAX=0x%lx\n",
             captured_regs.ip, captured_regs.sp, captured_regs.bp, captured_regs.ax,
             captured_regs.bx, captured_regs.cx, captured_regs.dx, captured_regs.si,
             captured_regs.di, captured_regs.r8, captured_regs.r9, captured_regs.r10,


### PR DESCRIPTION
Implements fixes for 3 code scanning findings, and adds crow_all.h to the ignore list, to prevent false positives.